### PR TITLE
Remove cron installed by default by certbot and use a custom one

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
----
 # Certbot certificates domains and emails
 certbot_certs: []
 # - domain: example1.com
@@ -14,3 +13,9 @@ certbot_logs_dir: "{{ certbot_base_dir }}"
 
 # Custom environment variables to set when running certbot
 certbot_environment_vars: {}
+
+# Certbot cron renewal
+certbot_auto_renew_options: "-q --config-dir {{ certbot_config_dir }}"
+certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+certbot_auto_renew_hour: "12"
+certbot_auto_renew_minute: "0"

--- a/tasks/configure-renewals.yml
+++ b/tasks/configure-renewals.yml
@@ -14,3 +14,16 @@
     mode: 0755
     owner: root
   when: certificate_dir.stat.exists
+
+- name: Remove default crontab file
+  file:
+    path: /etc/cron.d/certbot
+    state: absent
+
+- name: Add cron job for certbot renewal (if configured).
+  cron:
+    name: Certbot automatic renewal.
+    job: "certbot renew {{ certbot_auto_renew_options }}"
+    minute: "{{ certbot_auto_renew_minute }}"
+    hour: "{{ certbot_auto_renew_hour }}"
+    user: "{{ certbot_auto_renew_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,14 +8,14 @@
   package:
     name:
       - software-properties-common
-    update_cache: true
-    force_apt_get: true
+    update_cache: yes
+    force_apt_get: yes
     cache_valid_time: 3600
     state: latest
 
 - name: Add Universe repository.
   command: add-apt-repository universe
-  become: true
+  become: yes
 
 - name: Add Certbot repository.
   apt_repository:
@@ -40,7 +40,7 @@
       - certbot
       # - python-certbot-nginx
       - python3-certbot-dns-route53
-    update_cache: true
-    force_apt_get: true
+    update_cache: yes
+    force_apt_get: yes
     cache_valid_time: 3600
     state: latest


### PR DESCRIPTION
## what
* Remove cron installed by default by certbot and use a custom one

## why
* The default cron entry was failing to renew certificates because it didn't include the --config-dir flag
